### PR TITLE
Replace time.clock(); deprecated Python 3.8

### DIFF
--- a/src/translate/invariant_finder.py
+++ b/src/translate/invariant_finder.py
@@ -99,10 +99,10 @@ def find_invariants(task, reachable_action_params):
             candidates.append(invariant)
             seen_candidates.add(invariant)
 
-    start_time = time.clock()
+    start_time = time.perf_counter()
     while candidates:
         candidate = candidates.popleft()
-        if time.clock() - start_time > task.INVARIANT_TIME_LIMIT:
+        if time.perf_counter() - start_time > task.INVARIANT_TIME_LIMIT:
             print("Time limit reached, aborting invariant generation")
             return
         if candidate.check_balance(balance_checker, enqueue_func):


### PR DESCRIPTION
Very simple fix to be able to run it with Python 3.8, where `time.clock()` has been deprecated